### PR TITLE
feat: add ability to logout when using built-in auth module

### DIFF
--- a/src/components/SettingsButton/index.tsx
+++ b/src/components/SettingsButton/index.tsx
@@ -5,6 +5,7 @@ import { Toggle } from '@aiera/client-sdk/components/Toggle';
 import { Gear } from '@aiera/client-sdk/components/Svg/Gear';
 import { XMark } from '@aiera/client-sdk/components/Svg/XMark';
 import { Button } from '@aiera/client-sdk/components/Button';
+import { useAuthContext } from '@aiera/client-sdk/lib/auth';
 import './styles.css';
 
 interface SettingsButtonSharedProps {}
@@ -12,10 +13,11 @@ interface SettingsButtonSharedProps {}
 /** @notExported */
 interface SettingsButtonUIProps extends SettingsButtonSharedProps {
     hideTooltip?: () => void;
+    logout?: () => void;
 }
 
 function TooltipContent(props: SettingsButtonUIProps): ReactElement {
-    const { hideTooltip } = props;
+    const { hideTooltip, logout } = props;
     const { settings, handlers } = useSettings();
     return (
         <div className="shadow-md bg-white dark:bg-bluegray-6 rounded-lg w-44 overflow-hidden p-1">
@@ -54,14 +56,21 @@ function TooltipContent(props: SettingsButtonUIProps): ReactElement {
                     </span>
                 </div>
             )}
+            {logout && (
+                <div className="m-2 flex justify-end">
+                    <Button kind="primary" onClick={logout}>
+                        Logout
+                    </Button>
+                </div>
+            )}
         </div>
     );
 }
 
-export function SettingsButtonUI(_props: SettingsButtonUIProps): ReactElement {
+export function SettingsButtonUI({ logout }: SettingsButtonUIProps): ReactElement {
     return (
         <Tooltip
-            content={({ hideTooltip }) => <TooltipContent hideTooltip={hideTooltip} />}
+            content={({ hideTooltip }) => <TooltipContent hideTooltip={hideTooltip} logout={logout} />}
             grow="down-left"
             modal
             openOn="click"
@@ -82,5 +91,6 @@ export interface SettingsButtonProps extends SettingsButtonSharedProps {}
  * Renders SettingsButton
  */
 export function SettingsButton(): ReactElement {
-    return <SettingsButtonUI />;
+    const { logout } = useAuthContext();
+    return <SettingsButtonUI logout={logout} />;
 }

--- a/src/dev/EventList.tsx
+++ b/src/dev/EventList.tsx
@@ -107,7 +107,7 @@ const App: FC = (): ReactElement => {
                     },
                 }}
             >
-                <Auth showLogout>
+                <Auth>
                     <div className="h-full border border-black" ref={setModuleRef}>
                         <EventList />
                     </div>

--- a/src/dev/NewsList.tsx
+++ b/src/dev/NewsList.tsx
@@ -30,7 +30,7 @@ const App: FC = (): ReactElement => {
                     },
                 }}
             >
-                <Auth showLogout>
+                <Auth>
                     <div className="h-full border border-black">
                         <NewsList />
                     </div>

--- a/src/dev/RecordingList.tsx
+++ b/src/dev/RecordingList.tsx
@@ -24,7 +24,7 @@ const App: FC = (): ReactElement => {
                     },
                 }}
             >
-                <Auth showLogout>
+                <Auth>
                     <div className="h-full border border-black">
                         <RecordingList />
                     </div>

--- a/src/lib/auth/index.tsx
+++ b/src/lib/auth/index.tsx
@@ -1,0 +1,16 @@
+import React, { createContext, useContext, useMemo, ReactElement, ReactNode } from 'react';
+
+interface AuthContext {
+    logout?: () => void;
+}
+
+const Context = createContext<AuthContext>({});
+
+export const AuthProvider = ({ children, logout }: { children: ReactNode; logout?: () => void }): ReactElement => {
+    const authContext = useMemo(() => ({ logout }), [logout]);
+    return <Context.Provider value={authContext}>{children}</Context.Provider>;
+};
+
+export const useAuthContext = (): AuthContext => {
+    return useContext(Context);
+};

--- a/src/lib/auth/test.tsx
+++ b/src/lib/auth/test.tsx
@@ -1,0 +1,20 @@
+import React, { FC } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useAuthContext, AuthProvider } from '.';
+
+describe('realtime', () => {
+    test('returns undefined with no provider', () => {
+        const { result } = renderHook(() => useAuthContext());
+        expect(result.current.logout).toBeUndefined();
+    });
+
+    test('returns logout funciton when provided', () => {
+        const logout = jest.fn();
+
+        const Wrapper: FC = ({ children }) => {
+            return <AuthProvider logout={logout}>{children}</AuthProvider>;
+        };
+        const { result } = renderHook(() => useAuthContext(), { wrapper: Wrapper });
+        expect(result.current.logout).toBe(logout);
+    });
+});

--- a/src/modules/Auth/index.tsx
+++ b/src/modules/Auth/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, useState, FormEvent, FormEventHandler, MouseEventHandler } from 'react';
+import React, { ReactElement, ReactNode, useState, useCallback, FormEvent, FormEventHandler } from 'react';
 import { useMutation, useQuery } from 'urql';
 import gql from 'graphql-tag';
 import { match } from 'ts-pattern';
@@ -9,6 +9,7 @@ import { Button } from '@aiera/client-sdk/components/Button';
 import { Logo } from '@aiera/client-sdk/components/Svg/Logo';
 import { QueryError } from '@aiera/client-sdk/types';
 import { useClient } from '@aiera/client-sdk/api/client';
+import { AuthProvider } from '@aiera/client-sdk/lib/auth';
 import { useChangeHandlers, ChangeHandler } from '@aiera/client-sdk/lib/hooks/useChangeHandlers';
 import { AuthTokens, TokenAuthConfig, defaultTokenAuthConfig } from '@aiera/client-sdk/api/auth';
 import './styles.css';
@@ -23,9 +24,7 @@ interface AuthProps {
     error?: QueryError;
     loading: boolean;
     login: FormEventHandler;
-    logout: MouseEventHandler;
     loginState: LoginState;
-    showLogout: boolean;
     user?: CurrentUserQuery['currentUser'] | null;
     email: string;
     onChangeEmail: ChangeHandler<string>;
@@ -34,23 +33,7 @@ interface AuthProps {
 }
 
 export const AuthUI = (props: AuthProps): ReactElement => {
-    const {
-        children,
-        user,
-        loading,
-        login,
-        logout,
-        loginState,
-        showLogout,
-        email,
-        onChangeEmail,
-        password,
-        onChangePassword,
-    } = props;
-
-    if (loading) {
-        return <div>Loading...</div>;
-    }
+    const { children, user, loading, login, loginState, email, onChangeEmail, password, onChangePassword } = props;
 
     if (!user) {
         return (
@@ -58,122 +41,132 @@ export const AuthUI = (props: AuthProps): ReactElement => {
                 <div className="absolute w-32 top-10 right-10">
                     <Logo />
                 </div>
-                <div className="bg-white">
-                    <h1 className="text-3xl font-semibold text-left">Sign In</h1>
-                    <form className="mt-4" action="#" onSubmit={login}>
-                        <div className="mb-6">
-                            <label className="flex-1 mr-4 text-right" htmlFor="email">
-                                Email
-                            </label>
-                            <Input
-                                className="w-44"
-                                id="email"
-                                name="email"
-                                placeholder="email"
-                                value={email}
-                                onChange={onChangeEmail}
-                            />
+                {match(loading)
+                    .with(true, () => (
+                        <div className="flex">
+                            <div className="w-2 h-2 bg-[#FE590C] rounded-full animate-bounce animation" />
+                            <div className="w-2 h-2 ml-1 bg-[#FE590C] rounded-full animate-bounce animation-delay-100" />
+                            <div className="w-2 h-2 ml-1 bg-[#FE590C] rounded-full animate-bounce animation-delay-200" />
                         </div>
-                        <div>
-                            <label className="flex-1 mr-4 text-right" htmlFor="password">
-                                Password
-                            </label>
-                            <Input
-                                className="w-44"
-                                id="password"
-                                name="password"
-                                type="password"
-                                placeholder="password"
-                                value={password}
-                                onChange={onChangePassword}
-                            />
-                            <div className="flex justify-end mt-1">
-                                <a
-                                    className="right-0 text-xs text-gray-500 cursor-pointer hover:underline"
-                                    href="https://dashboard.aiera.com/auth/reset-password"
-                                    target="_blank"
-                                    rel="noreferrer"
-                                >
-                                    Forgot Password?
-                                </a>
-                            </div>
-                        </div>
-                        <div className="flex items-center justify-center h-10">
-                            {match(loginState)
-                                .with('error', () => (
-                                    <div className="text-sm text-red-500">There was an error logging in.</div>
-                                ))
-                                .otherwise(() => null)}
-                        </div>
-                        <div className="flex justify-center">
-                            {match(loginState)
-                                .with('none', 'error', () => {
-                                    return (
-                                        <Button className="justify-center w-32" kind="primary" type="submit">
-                                            Login
-                                        </Button>
-                                    );
-                                })
-                                .with('loading', () => {
-                                    return (
-                                        <Button className="justify-center w-32" disabled kind="primary">
-                                            <div className="w-2 h-2 bg-white rounded-full animate-bounce animation" />
-                                            <div className="w-2 h-2 ml-1 bg-white rounded-full animate-bounce animation-delay-100" />
-                                            <div className="w-2 h-2 ml-1 bg-white rounded-full animate-bounce animation-delay-200" />
-                                        </Button>
-                                    );
-                                })
-                                .exhaustive()}
-                        </div>
-                        <div className="flex justify-center mt-2">
-                            {match(loginState)
-                                .with('none', 'error', () => {
-                                    return (
-                                        <a href="https://dashboard.aiera.com/pricing" target="_blank" rel="noreferrer">
-                                            <Button className="justify-center w-32" kind="secondary" type="button">
-                                                Sign Up
-                                            </Button>
+                    ))
+                    .with(false, () => (
+                        <div className="bg-white">
+                            <h1 className="text-3xl font-semibold text-left">Sign In</h1>
+                            <form className="mt-4" action="#" onSubmit={login}>
+                                <div className="mb-6">
+                                    <label className="flex-1 mr-4 text-right" htmlFor="email">
+                                        Email
+                                    </label>
+                                    <Input
+                                        className="w-44"
+                                        id="email"
+                                        name="email"
+                                        placeholder="email"
+                                        value={email}
+                                        onChange={onChangeEmail}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="flex-1 mr-4 text-right" htmlFor="password">
+                                        Password
+                                    </label>
+                                    <Input
+                                        className="w-44"
+                                        id="password"
+                                        name="password"
+                                        type="password"
+                                        placeholder="password"
+                                        value={password}
+                                        onChange={onChangePassword}
+                                    />
+                                    <div className="flex justify-end mt-1">
+                                        <a
+                                            className="right-0 text-xs text-gray-500 cursor-pointer hover:underline"
+                                            href="https://dashboard.aiera.com/auth/reset-password"
+                                            target="_blank"
+                                            rel="noreferrer"
+                                        >
+                                            Forgot Password?
                                         </a>
-                                    );
-                                })
-                                .with('loading', () => {
-                                    return (
-                                        <Button className="justify-center w-32" disabled kind="secondary" type="button">
-                                            Sign Up
-                                        </Button>
-                                    );
-                                })
-                                .exhaustive()}
+                                    </div>
+                                </div>
+                                <div className="flex items-center justify-center h-10">
+                                    {match(loginState)
+                                        .with('error', () => (
+                                            <div className="text-sm text-red-500">There was an error logging in.</div>
+                                        ))
+                                        .otherwise(() => null)}
+                                </div>
+                                <div className="flex justify-center">
+                                    {match(loginState)
+                                        .with('none', 'error', () => {
+                                            return (
+                                                <Button className="justify-center w-32" kind="primary" type="submit">
+                                                    Login
+                                                </Button>
+                                            );
+                                        })
+                                        .with('loading', () => {
+                                            return (
+                                                <Button className="justify-center w-32" disabled kind="primary">
+                                                    <div className="w-2 h-2 bg-white rounded-full animate-bounce animation" />
+                                                    <div className="w-2 h-2 ml-1 bg-white rounded-full animate-bounce animation-delay-100" />
+                                                    <div className="w-2 h-2 ml-1 bg-white rounded-full animate-bounce animation-delay-200" />
+                                                </Button>
+                                            );
+                                        })
+                                        .exhaustive()}
+                                </div>
+                                <div className="flex justify-center mt-2">
+                                    {match(loginState)
+                                        .with('none', 'error', () => {
+                                            return (
+                                                <a
+                                                    href="https://dashboard.aiera.com/pricing"
+                                                    target="_blank"
+                                                    rel="noreferrer"
+                                                >
+                                                    <Button
+                                                        className="justify-center w-32"
+                                                        kind="secondary"
+                                                        type="button"
+                                                    >
+                                                        Sign Up
+                                                    </Button>
+                                                </a>
+                                            );
+                                        })
+                                        .with('loading', () => {
+                                            return (
+                                                <Button
+                                                    className="justify-center w-32"
+                                                    disabled
+                                                    kind="secondary"
+                                                    type="button"
+                                                >
+                                                    Sign Up
+                                                </Button>
+                                            );
+                                        })
+                                        .exhaustive()}
+                                </div>
+                            </form>
                         </div>
-                    </form>
-                </div>
+                    ))
+                    .exhaustive()}
             </div>
         );
     }
 
-    return (
-        <div className="h-full">
-            {(showLogout || !children) && (
-                <div className="h-6">
-                    Logged in as {user.firstName} {user.lastName}
-                    <button className="px-1 ml-2 text-white bg-blue-500 rounded" onClick={logout}>
-                        Logout
-                    </button>
-                </div>
-            )}
-            {children && <div className="h-full pb-6">{children}</div>}
-        </div>
-    );
+    return <div className="h-full">{children}</div>;
 };
 
 export const Auth = ({
     children,
     config = defaultTokenAuthConfig,
-    showLogout = false,
 }: {
     children?: ReactNode;
     config?: TokenAuthConfig<AuthTokens>;
-    showLogout?: boolean;
 }): ReactElement => {
     const initialAuthform = { email: '', password: '' };
     const { state, mergeState, handlers } = useChangeHandlers(initialAuthform);
@@ -202,45 +195,48 @@ export const Auth = ({
 
     const { reset } = useClient();
 
-    const login = async (event: FormEvent) => {
-        event.preventDefault();
-        setLoginState('loading');
-        return loginMutation(state)
-            .then(async (resp) => {
-                if (resp.data?.login) {
-                    await config.writeAuth(resp.data.login);
-                    refetch({ requestPolicy: 'cache-and-network' });
-                    setLoginState('none');
-                } else {
-                    throw new Error('Error logging in');
-                }
-            })
-            .catch((_e) => {
-                setLoginState('error');
-            });
-    };
+    const login = useCallback(
+        async (event: FormEvent) => {
+            event.preventDefault();
+            setLoginState('loading');
+            return loginMutation(state)
+                .then(async (resp) => {
+                    if (resp.data?.login) {
+                        await config.writeAuth(resp.data.login);
+                        refetch({ requestPolicy: 'cache-and-network' });
+                        setLoginState('none');
+                    } else {
+                        throw new Error('Error logging in');
+                    }
+                })
+                .catch((_e) => {
+                    setLoginState('error');
+                });
+        },
+        [loginMutation, config, refetch, state, setLoginState]
+    );
 
-    const logout = async () => {
+    const logout = useCallback(async () => {
         await config.clearAuth();
         mergeState(initialAuthform);
         reset();
-    };
+    }, [config, mergeState, reset]);
 
     return (
-        <AuthUI
-            user={result.data?.currentUser}
-            loading={result.fetching}
-            error={result.error}
-            email={state.email}
-            onChangeEmail={handlers.email}
-            password={state.password}
-            onChangePassword={handlers.password}
-            login={login}
-            logout={logout}
-            showLogout={showLogout}
-            loginState={loginState}
-        >
-            {children}
-        </AuthUI>
+        <AuthProvider logout={logout}>
+            <AuthUI
+                user={result.data?.currentUser}
+                loading={result.fetching}
+                error={result.error}
+                email={state.email}
+                onChangeEmail={handlers.email}
+                password={state.password}
+                onChangePassword={handlers.password}
+                login={login}
+                loginState={loginState}
+            >
+                {children}
+            </AuthUI>
+        </AuthProvider>
     );
 };


### PR DESCRIPTION
This PR adds real logout support for platforms that use our login form instead of SSO. The `Logout` button now shows in the settings widget only when there's a `logout` function provided, which our Auth module now provides.

This means that the `<SettingsButton />` component will need to be rendered for all modules, though I think that works since the `Dark Mode` setting applies to all modules anyway.

![image](https://user-images.githubusercontent.com/3680882/153226530-d4f9bb66-477b-4096-a944-a1b1b9ac0b43.png)
