### PR TITLE
feat: show times relative to first transcript item's start_ms when displaying Transcript with relativeTimestamps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aiera/client-sdk",
-    "version": "0.0.37",
+    "version": "0.0.38",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@aiera/client-sdk",
-            "version": "0.0.37",
+            "version": "0.0.38",
             "license": "CC-BY-NC-ND-4.0",
             "dependencies": {
                 "@urql/devtools": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aiera/client-sdk",
-    "version": "0.0.37",
+    "version": "0.0.38",
     "description": "The Aiera Client SDK",
     "author": "Aiera, Inc.",
     "license": "CC-BY-NC-ND-4.0",


### PR DESCRIPTION
# Trello card link

https://trello.com/c/BFtkJhQM/1704-when-displaying-transcripts-with-relativetimestamps-in-the-components-use-the-first-items-startms-as-an-offset-to-show-00000-whe

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security

## Acceptance

https://www.notion.so/aiera/Test-Flows-Template-5203736ccfcb424c81643065f2bbf5e2

- [ ] I have reviewed the Test Flows template and it is up-to-date after considering my changes
