### PR TITLE
fix: refetch current user and app config queries until both are set before setting Pusher client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aiera/client-sdk",
-    "version": "0.0.54",
+    "version": "0.0.55",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@aiera/client-sdk",
-            "version": "0.0.54",
+            "version": "0.0.55",
             "license": "CC-BY-NC-ND-4.0",
             "dependencies": {
                 "@dnd-kit/core": "^6.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aiera/client-sdk",
-    "version": "0.0.54",
+    "version": "0.0.55",
     "description": "The Aiera Client SDK",
     "author": "Aiera, Inc.",
     "license": "CC-BY-NC-ND-4.0",

--- a/src/lib/realtime/index.tsx
+++ b/src/lib/realtime/index.tsx
@@ -1,9 +1,15 @@
 import React, { createContext, useEffect, useState, useContext, ReactNode, ReactElement } from 'react';
+import gql from 'graphql-tag';
 import Pusher from 'pusher-js';
 import merge from 'lodash.merge';
 
+import { useQuery } from '@aiera/client-sdk/api/client';
 import { useConfig } from '@aiera/client-sdk/lib/config';
 import { useAppConfig } from '@aiera/client-sdk/lib/data';
+import { AppConfigQuery, RealtimeCurrentUserQuery } from '@aiera/client-sdk/types/generated';
+
+type AppConfiguration = AppConfigQuery['configuration'];
+type RealtimeCurrentUser = RealtimeCurrentUserQuery['currentUser'];
 
 export type Realtime = Pusher;
 
@@ -11,15 +17,60 @@ export const Context = createContext<Realtime | undefined>(undefined);
 
 export function Provider({ children, client: passedClient }: { children: ReactNode; client?: Pusher }): ReactElement {
     const [client, setClient] = useState<Realtime | undefined>(passedClient);
-    const configQuery = useAppConfig();
-    const { realtimeOptions } = useConfig();
+
+    // Keep current user and Pusher config in state
+    // If the config isn't set, wait until user is authed to refetch
+    // And only then set the Pusher client
+    const [appConfig, setAppConfig] = useState<AppConfiguration | undefined>(undefined);
+    const [currentUser, setCurrentUser] = useState<RealtimeCurrentUser | undefined>(undefined);
+
+    // Auth needed to retrieve Pusher config from server
+    const userQuery = useQuery<RealtimeCurrentUserQuery>({
+        requestPolicy: 'cache-only',
+        query: gql`
+            query RealtimeCurrentUser {
+                currentUser {
+                    id
+                }
+            }
+        `,
+    });
     useEffect(() => {
-        const appKey = configQuery.state.data?.configuration?.pusherAppKey;
-        const cluster = configQuery.state.data?.configuration?.pusherAppCluster;
-        if (!passedClient && appKey && cluster) {
+        if (!currentUser) {
+            if (userQuery.status === 'success' && userQuery.state.data?.currentUser?.id) {
+                setCurrentUser(userQuery.state.data.currentUser);
+            } else if (
+                userQuery.status === 'error' ||
+                (userQuery.status === 'success' && !userQuery.state.data?.currentUser?.id)
+            ) {
+                userQuery.refetch({ requestPolicy: 'cache-and-network' });
+            }
+        }
+    }, [currentUser, userQuery.state.data?.currentUser, userQuery.status]);
+
+    const configQuery = useAppConfig();
+    useEffect(() => {
+        if (!appConfig && currentUser) {
+            if (configQuery.status === 'success' && configQuery.state.data?.configuration) {
+                setAppConfig(configQuery.state.data.configuration);
+            } else if (
+                configQuery.status === 'error' ||
+                (configQuery.status === 'success' && !configQuery.data?.configuration)
+            ) {
+                configQuery.refetch();
+            }
+        }
+    }, [appConfig, configQuery.state.data?.configuration, configQuery.status, currentUser]);
+
+    const { realtimeOptions } = useConfig();
+    console.log({ appConfig, currentUser, client });
+    useEffect(() => {
+        const appKey = appConfig?.pusherAppKey;
+        const cluster = appConfig?.pusherAppCluster;
+        if (!client && !passedClient && appKey && cluster) {
             setClient(new Pusher(appKey, merge({ cluster }, realtimeOptions)));
         }
-    }, [configQuery.state.data?.configuration?.pusherAppKey, configQuery.state.data?.configuration?.pusherAppKey]);
+    }, [appConfig, client, passedClient]);
     return <Context.Provider value={client}>{children}</Context.Provider>;
 }
 

--- a/src/lib/realtime/index.tsx
+++ b/src/lib/realtime/index.tsx
@@ -63,7 +63,6 @@ export function Provider({ children, client: passedClient }: { children: ReactNo
     }, [appConfig, configQuery.state.data?.configuration, configQuery.status, currentUser]);
 
     const { realtimeOptions } = useConfig();
-    console.log({ appConfig, currentUser, client });
     useEffect(() => {
         const appKey = appConfig?.pusherAppKey;
         const cluster = appConfig?.pusherAppCluster;


### PR DESCRIPTION
# Trello card link

https://trello.com/c/p095Jxsf/1882-fix-race-condition-in-setting-up-realtime-transcript-updates-via-pusher-in-components

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security

## Acceptance

https://www.notion.so/aiera/Test-Flows-Template-5203736ccfcb424c81643065f2bbf5e2

- [ ] I have reviewed the Test Flows template and it is up-to-date after considering my changes
