### PR TITLE
Update chat session status in zustand if messages query has updated s…

### DIFF
--- a/src/modules/AieraChat/components/AnimatedLoadingStatus/index.tsx
+++ b/src/modules/AieraChat/components/AnimatedLoadingStatus/index.tsx
@@ -1,11 +1,6 @@
 import classNames from 'classnames';
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { Loading } from '@aiera/client-sdk/modules/AieraChat/components/Messages/MessageFactory/Loading';
-import { Source } from '../../store';
-
-interface AnimatedLoadingProps {
-    sources: Source[];
-}
 
 // Define an interface for message configuration
 interface StatusMessage {
@@ -13,7 +8,7 @@ interface StatusMessage {
     durationMs: number | [number, number]; // Fixed duration or [min, max] for random range
 }
 
-export function AnimatedLoadingStatus({ sources = [] }: AnimatedLoadingProps) {
+export function AnimatedLoadingStatus() {
     const [loadingText, setLoadingText] = useState('Thinking...');
     const [isVisible, setIsVisible] = useState(true);
     const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -22,23 +17,11 @@ export function AnimatedLoadingStatus({ sources = [] }: AnimatedLoadingProps) {
     // Define messages with custom durations
     const messages = useMemo(
         (): StatusMessage[] => [
-            { text: 'Thinking...', durationMs: [3000, 5000] }, // Random between 3-5 seconds
-            { text: 'Finding sources...', durationMs: [2000, 3000] }, // Random between 2-4 seconds
-            {
-                text: `Successfully found ${sources.length} ${sources.length === 1 ? 'source' : 'sources'}`,
-                durationMs: 1000, // Fixed at 1 second - shorter duration
-            },
-            {
-                text: `Analyzing ${sources.length} ${sources.length === 1 ? 'source' : 'sources'}...`,
-                durationMs: [4000, 6000],
-            },
-            { text: 'Reasoning...', durationMs: [3000, 5000] },
-            { text: 'Invoking agent...', durationMs: [2000, 4000] },
-            { text: 'Processing results...', durationMs: [3000, 4000] },
-            { text: 'Finalizing response...', durationMs: [6000, 10000] },
-            { text: 'Still working...', durationMs: 10000 }, // duration doesn't matter for the last message
+            { text: 'Thinking...', durationMs: [2000, 3000] }, // Random between 2-3 seconds
+            { text: 'Finding sources...', durationMs: [3000, 5000] }, // Random between 3-5 seconds
+            { text: 'Still working...', durationMs: 1000 }, // Duration doesn't matter for the last message
         ],
-        [sources]
+        []
     );
 
     // Function to get the message text at a specific index

--- a/src/modules/AieraChat/components/Messages/MessageFactory/SourcesResponse/index.tsx
+++ b/src/modules/AieraChat/components/Messages/MessageFactory/SourcesResponse/index.tsx
@@ -19,19 +19,25 @@ export const SourcesResponse = ({
     const [showSourceDialog, setShowSourceDialog] = useState<boolean>(false);
     const [localSources, setLocalSources] = useState<Source[]>(data.sources);
 
-    const onAddSource = useCallback((s: Source) => {
-        setLocalSources((pv) => [...pv, s]);
-    }, []);
+    const onAddSource = useCallback(
+        (s: Source) => {
+            setLocalSources((pv) => [...pv, s]);
+        },
+        [setLocalSources]
+    );
 
-    const onRemoveSource = useCallback((s: Source) => {
-        setLocalSources((pv) =>
-            pv.filter((source) => !(source.targetId === s.targetId && source.targetType === s.targetType))
-        );
-    }, []);
+    const onRemoveSource = useCallback(
+        (s: Source) => {
+            setLocalSources((pv) =>
+                pv.filter((source) => !(source.targetId === s.targetId && source.targetType === s.targetType))
+            );
+        },
+        [setLocalSources]
+    );
 
     useEffect(() => {
         setLocalSources(data.sources);
-    }, [data.sources]);
+    }, [data.sources, setLocalSources]);
 
     if (data.confirmed) {
         return <div />;

--- a/src/modules/AieraChat/components/Messages/Prompt/index.tsx
+++ b/src/modules/AieraChat/components/Messages/Prompt/index.tsx
@@ -6,15 +6,17 @@ import { MicroFolderOpen } from '../../../../../components/Svg/MicroFolderOpen';
 import { useChatStore } from '../../../store';
 import { Hint } from '../../Hint';
 import './styles.css';
+import { ChatSessionStatus } from '@aiera/client-sdk/types';
 
 interface PromptProps {
     onOpenSources: () => void;
     onSubmit: (prompt: string) => void;
+    submitting: boolean;
 }
 
-export function Prompt({ onSubmit, onOpenSources }: PromptProps) {
-    const { sources } = useChatStore();
-    const [isEmpty, setIsEmpty] = useState(true);
+export function Prompt({ onSubmit, onOpenSources, submitting }: PromptProps) {
+    const { chatStatus, sources } = useChatStore();
+    const [isEmpty, setIsEmpty] = useState<boolean>(true);
     const inputRef = useRef<HTMLParagraphElement | null>(null);
 
     const checkEmpty = useCallback(() => {
@@ -75,6 +77,7 @@ export function Prompt({ onSubmit, onOpenSources }: PromptProps) {
                 </span>
             )}
             <button
+                disabled={chatStatus !== ChatSessionStatus.Active}
                 onClick={onOpenSources}
                 className={classNames(
                     'h-[1.875rem] ml-2 self-end mb-1 mr-[5px] px-1.5 transition-all',
@@ -105,6 +108,7 @@ export function Prompt({ onSubmit, onOpenSources }: PromptProps) {
                 />
             </button>
             <button
+                disabled={submitting}
                 onClick={handleSubmit}
                 className={classNames(
                     'h-[1.875rem] self-end mb-1 mr-[5px] w-[1.875rem] transition-all',

--- a/src/modules/AieraChat/components/Messages/index.tsx
+++ b/src/modules/AieraChat/components/Messages/index.tsx
@@ -29,6 +29,7 @@ import { useConfig } from '@aiera/client-sdk/lib/config';
 import { ChatSessionWithPromptMessage } from '@aiera/client-sdk/modules/AieraChat/services/types';
 import { ChatSessionStatus } from '@aiera/client-sdk/types';
 import { useAbly } from '@aiera/client-sdk/modules/AieraChat/services/ably';
+import { AnimatedLoadingStatus } from '@aiera/client-sdk/modules/AieraChat/components/AnimatedLoadingStatus';
 
 const STREAMING_STATUSES = [ChatSessionStatus.FindingSources, ChatSessionStatus.GeneratingResponse];
 let idCounter = 0;
@@ -317,7 +318,13 @@ export function Messages({
         if (confirmation) {
             const existing = virtuosoRef.current?.data.find((m) => m.id === confirmation.id);
             if (!existing) {
-                virtuosoRef.current?.data.append([confirmation], ({ scrollInProgress, atBottom }) => {
+                // Find the associated prompt message to ensure sticky header works
+                const promptMessage = virtuosoRef.current?.data.find((m) => m.id === confirmation.promptMessageId);
+                const updatedConfirmation = {
+                    ...confirmation,
+                    prompt: promptMessage?.prompt ?? '',
+                };
+                virtuosoRef.current?.data.append([updatedConfirmation], ({ scrollInProgress, atBottom }) => {
                     return {
                         index: 'LAST',
                         align: 'end',
@@ -359,7 +366,7 @@ export function Messages({
                             ref={virtuosoRef}
                             style={{ flex: 1 }}
                             computeItemKey={({ data }: { data: ChatMessage }) => data.id}
-                            className="mb-4 px-4 messagesScrollBars"
+                            className="px-4 messagesScrollBars"
                             initialLocation={{ index: 'LAST', align: 'end' }}
                             initialData={messages}
                             shortSizeAlign="bottom-smooth"
@@ -370,6 +377,7 @@ export function Messages({
                         />
                     </VirtuosoMessageListLicense>
                 )}
+                {chatStatus === ChatSessionStatus.FindingSources && !confirmation && <AnimatedLoadingStatus />}
                 <Prompt onSubmit={handleSubmit} onOpenSources={onOpenSources} />
             </div>
         </div>

--- a/src/modules/AieraChat/components/Messages/index.tsx
+++ b/src/modules/AieraChat/components/Messages/index.tsx
@@ -151,7 +151,7 @@ export function Messages({
                     console.log('Error confirming sources for chat message source confirmation:', err)
                 );
         },
-        [confirmSourceConfirmation]
+        [confirmSourceConfirmation, onAddSource, virtuosoRef.current?.data]
     );
 
     const handleSubmit = useCallback(
@@ -211,7 +211,7 @@ export function Messages({
                     .finally(() => setSubmitting(false));
             }
         },
-        [chatId, createAblyToken, onSetStatus, setSubmitting, sources]
+        [chatId, createAblyToken, onSetStatus, setSubmitting, sources, virtuosoRef.current?.data]
     );
 
     // Append new messages to virtuoso as they're created
@@ -233,7 +233,7 @@ export function Messages({
                 });
             }
         }
-    }, [messages]);
+    }, [messages, virtuosoRef.current?.data]);
 
     // Process partial messages from Ably for streaming
     useEffect(() => {
@@ -276,12 +276,14 @@ export function Messages({
             } else {
                 // Get the latest prompt to ensure the sticky header works
                 const items = virtuosoRef.current?.data.get() || [];
-                const latestPrompt = [...items].reverse().find((message) => message.type === ChatMessageType.PROMPT);
+                const latestPrompt = items.reverse().find((message) => message.type === ChatMessageType.PROMPT);
+
                 // If there's no streaming message yet, append one to virtuoso using existing partials
                 const initialMessageResponse: ChatMessageResponse = {
                     id: `chat-${chatId}-temp-response-${idCounter++}`,
                     ordinalId: `chat-${chatId}-temp-ordinal-${idCounter++}`,
                     prompt: latestPrompt?.prompt || '',
+                    promptMessageId: latestPrompt?.id ? String(latestPrompt.id) : undefined,
                     status: ChatMessageStatus.STREAMING,
                     timestamp: new Date().toISOString(),
                     type: ChatMessageType.RESPONSE,

--- a/src/modules/AieraChat/components/Messages/index.tsx
+++ b/src/modules/AieraChat/components/Messages/index.tsx
@@ -307,9 +307,12 @@ export function Messages({
     }, [chatStatus, partials, virtuosoRef.current?.data]);
 
     useEffect(() => {
+        // If streaming has stopped
         if (!isStreaming && partials && partials.length > 0 && STREAMING_STATUSES.includes(chatStatus)) {
-            // If streaming has stopped, refetch the ChatSessionWithMessagesQuery query
-            // to get the final response and updated chat title
+            // Set chat session status back to active
+            onSetStatus(ChatSessionStatus.Active);
+
+            // Refetch the ChatSessionWithMessagesQuery query to get the final response and updated chat title
             reset()
                 .then(() => {
                     setTimeout(() => {
@@ -318,7 +321,7 @@ export function Messages({
                 })
                 .catch((err: Error) => console.log(`Error resetting useAbly state: ${err.message}`));
         }
-    }, [chatStatus, isStreaming, partials, refresh, reset]);
+    }, [chatStatus, isStreaming, onSetStatus, partials, refresh, reset]);
 
     // Update virtuoso with any source confirmation messages coming from Ably
     useEffect(() => {

--- a/src/modules/AieraChat/components/Messages/index.tsx
+++ b/src/modules/AieraChat/components/Messages/index.tsx
@@ -274,11 +274,14 @@ export function Messages({
                     }
                 );
             } else {
+                // Get the latest prompt to ensure the sticky header works
+                const items = virtuosoRef.current?.data.get() || [];
+                const latestPrompt = [...items].reverse().find((message) => message.type === ChatMessageType.PROMPT);
                 // If there's no streaming message yet, append one to virtuoso using existing partials
                 const initialMessageResponse: ChatMessageResponse = {
                     id: `chat-${chatId}-temp-response-${idCounter++}`,
                     ordinalId: `chat-${chatId}-temp-ordinal-${idCounter++}`,
-                    prompt: latestMessage?.prompt || '', // TODO all messages need to know the prompt
+                    prompt: latestPrompt?.prompt || '',
                     status: ChatMessageStatus.STREAMING,
                     timestamp: new Date().toISOString(),
                     type: ChatMessageType.RESPONSE,

--- a/src/modules/AieraChat/panels/Sources/index.tsx
+++ b/src/modules/AieraChat/panels/Sources/index.tsx
@@ -14,7 +14,7 @@ import { Source, useChatStore } from '../../store';
 import { ContentRow } from '../../components/ContentRow';
 import { MicroDocumentSearch } from '@aiera/client-sdk/components/Svg/MicroDocumentSearch';
 
-const EMPTY_SOURCES_MESSAGE = 'You must select at least one source to submit a question.';
+const EMPTY_SOURCES_MESSAGE = 'Sources will be suggested until a source is added.';
 
 /**
  * Checks if a given source exists in an array of sources

--- a/src/modules/AieraChat/services/ably.ts
+++ b/src/modules/AieraChat/services/ably.ts
@@ -201,7 +201,13 @@ export const useAbly = (): UseAblyReturn => {
                                     }
 
                                     // Decode the base64 string
-                                    const decodedData = atob(data.content);
+                                    let decodedData;
+                                    try {
+                                        decodedData = atob(data.content);
+                                    } catch (decodingError) {
+                                        console.log('Error handling message:', decodingError);
+                                        return; // ignore message if there's no encoded content
+                                    }
 
                                     // Parse the JSON
                                     const jsonObject = JSON.parse(decodedData) as AblyMessageData;
@@ -232,7 +238,9 @@ export const useAbly = (): UseAblyReturn => {
                                                 }`,
                                                 ordinalId: jsonObject.ordinal_id,
                                                 prompt: '', // placeholder, get text from virtuoso using the prompt id
-                                                promptMessageId: jsonObject.prompt_message_id ?? undefined,
+                                                promptMessageId: jsonObject.prompt_message_id
+                                                    ? String(jsonObject.prompt_message_id)
+                                                    : undefined,
                                                 sources,
                                                 status: ChatMessageStatus.COMPLETED,
                                                 timestamp: jsonObject.created_at,

--- a/src/modules/AieraChat/services/messages.ts
+++ b/src/modules/AieraChat/services/messages.ts
@@ -551,7 +551,7 @@ export const useChatSession = ({
     enablePolling = false,
     requestPolicy = 'cache-and-network',
 }: UseChatSessionOptions): UseChatSessionReturn => {
-    const { chatId, chatTitle, onSetTitle, setCitations } = useChatStore();
+    const { chatId, chatStatus, chatTitle, onSetStatus, onSetTitle, setCitations } = useChatStore();
     const [messages, setMessages] = useState<ChatMessage[]>([]);
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
@@ -727,6 +727,11 @@ export const useChatSession = ({
                 const chatSession = messagesQuery.data.chatSession;
                 console.log('Processing chat session:', chatSession.id);
 
+                // Update chat status in store if it changes
+                if (chatStatus !== chatSession.status) {
+                    onSetStatus(chatSession.status);
+                }
+
                 // Update chat title in store if the session got a generated title
                 if (
                     chatSession.title &&
@@ -854,7 +859,18 @@ export const useChatSession = ({
                 setShouldStopPolling(true);
             }
         }
-    }, [chatTitle, enablePolling, error, isLoading, messagesQuery, onSetTitle, setError, setMessages]);
+    }, [
+        chatStatus,
+        chatTitle,
+        enablePolling,
+        error,
+        isLoading,
+        messagesQuery,
+        onSetStatus,
+        onSetTitle,
+        setError,
+        setMessages,
+    ]);
 
     useEffect(() => {
         // Immediately clear messages when changing sessions

--- a/src/modules/AieraChat/services/messages.ts
+++ b/src/modules/AieraChat/services/messages.ts
@@ -639,10 +639,10 @@ export const useChatSession = ({
                         const normalizedMessage: ChatMessagePrompt = {
                             id: newMessage.id,
                             ordinalId: newMessage.ordinalId,
-                            timestamp: newMessage.createdAt,
-                            status: ChatMessageStatus.COMPLETED,
-                            type: ChatMessageType.PROMPT,
                             prompt: newMessage.content,
+                            status: ChatMessageStatus.COMPLETED,
+                            timestamp: newMessage.createdAt,
+                            type: ChatMessageType.PROMPT,
                         };
 
                         console.log('Created new message:', normalizedMessage);
@@ -784,7 +784,7 @@ export const useChatSession = ({
                             id: msg.id,
                             ordinalId: msg.ordinalId,
                             prompt: lastPromptValue, // Use the last prompt value
-                            promptMessageId: String(msg.promptMessageId) ?? undefined,
+                            promptMessageId: msg.promptMessageId ? String(msg.promptMessageId) : undefined,
                             sources: normalizeSources(msg.sources),
                             status: ChatMessageStatus.COMPLETED,
                             timestamp: msg.createdAt,
@@ -806,7 +806,7 @@ export const useChatSession = ({
                             id: msg.id,
                             ordinalId: msg.ordinalId,
                             prompt: lastPromptValue, // Use the last prompt value
-                            promptMessageId: String(msg.promptMessageId) ?? undefined,
+                            promptMessageId: msg.promptMessageId ? String(msg.promptMessageId) : undefined,
                             sources,
                             status: ChatMessageStatus.COMPLETED,
                             timestamp: msg.createdAt,


### PR DESCRIPTION
…tatus, show animated loading while 'finding_sources', and fix sticky header for confirmation messages in virtuoso

## 🎯 What is the purpose/goal of this PR?






## ℹ️ Summarize the changes made






## 📌 Related Resources

_Links to any additional context such as tracking issues/cards, previous or related PRs, slack conversations,
and updated/new documentation related to this PR_

* Monday Kanban Card Link: <https://aiera-force.monday.com/boards/7610926381/>
* Slack Thread Link:
* Updated/New Documentation Link:
* 

## Test Flows

- [ ] Insert the test flows required here
  - [ ] complete with subtasks as necessary to ensure clarity


## 🚀 Checklist before requesting a review

- [ ] I have performed a self-review/test of my code locally with the above documented test flows
- [ ] I have performed a self-review/test of my code on dev/staging (_not available on all repos_)
- [ ] I have documented the required test flows on the this PR
- [ ] I have made corresponding changes to the documentation or added new documentation where needed
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] There are **NO** security concerns with the changes made

⚠️ 🛑 **You MUST checkoff all items. Anything left unchecked MUST be explained below in detail.** 🛑 ⚠️


## 🔭 Additional Information



