### PR TITLE
Move is_final check to beginning so that the streaming stops

### DIFF
--- a/src/modules/AieraChat/services/ably.ts
+++ b/src/modules/AieraChat/services/ably.ts
@@ -326,6 +326,13 @@ export const useAbly = (): UseAblyReturn => {
                         return; // ignore message if there's no encoded content
                     }
 
+                    // Stop streaming if this is the final partial
+                    if (data.is_final) {
+                        log('Received final partial:', 'log', data);
+                        onSetStatus(ChatSessionStatus.Active);
+                        return;
+                    }
+
                     // Parse the JSON
                     const jsonObject = JSON.parse(decodedData) as AblyMessageData;
                     log('Decoded Ably message:', 'log', jsonObject);
@@ -397,11 +404,6 @@ export const useAbly = (): UseAblyReturn => {
                         }
                     }
 
-                    // Stop streaming if this is the final partial
-                    if (data.is_final) {
-                        log('Received final partial:', 'log', data);
-                        onSetStatus(ChatSessionStatus.Active);
-                    }
                 } catch (err) {
                     log(`Error handling message: ${String(err)}`, 'error');
                     setError(`Error handling message: ${(err as Error).message}`);


### PR DESCRIPTION
## 🎯 What is the purpose/goal of this PR?
Probable fix for duped message in chat body.

Chat publishes the full message content blocks etc. using the is_final flag = True
Ably pushes the final message to the same channel as partials... 
 https://github.com/aiera-inc/aiera-ably-lambda/blob/5b24c71e31a37f7ec837191d54a88b5ea4d5b774/aiera_ably_lambda/app/handler.py#L79
But sdk is processing the body before checking if the message is final
https://github.com/aiera-inc/aiera-client-sdk/blob/b655a6331d9ba5eda63d6a56c3875da7295c9df0/src/modules/AieraChat/services/ably.ts#L400


## ℹ️ Summarize the changes made
Move is_final check to beginning so that the streaming stops



## 📌 Related Resources

_Links to any additional context such as tracking issues/cards, previous or related PRs, slack conversations,
and updated/new documentation related to this PR_

* Monday Kanban Card Link: <https://aiera-force.monday.com/boards/7610926381/>
* Slack Thread Link:
* Updated/New Documentation Link:
* 

## Test Flows

- [ ] Insert the test flows required here
  - [ ] complete with subtasks as necessary to ensure clarity


## 🚀 Checklist before requesting a review

- [x] I have performed a self-review/test of my code locally with the above documented test flows
- [ ] I have performed a self-review/test of my code on dev/staging (_not available on all repos_)
- [ ] I have documented the required test flows on the this PR
- [ ] I have made corresponding changes to the documentation or added new documentation where needed
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] There are **NO** security concerns with the changes made

⚠️ 🛑 **You MUST checkoff all items. Anything left unchecked MUST be explained below in detail.** 🛑 ⚠️


## 🔭 Additional Information


